### PR TITLE
fixes "fatal error: floating point value cannot be converted to Int32…

### DIFF
--- a/dist/JsonServiceClient.swift
+++ b/dist/JsonServiceClient.swift
@@ -2447,7 +2447,7 @@ public extension NSDate {
     }
     
     public var jsonDate:String {
-        let unixEpoch = Int(self.timeIntervalSince1970 * 1000)
+        let unixEpoch = UInt64(self.timeIntervalSince1970 * 1000)
         return "/Date(\(unixEpoch)-0000)/"
     }
     

--- a/dist/XCode/7.0/JsonServiceClient.swift
+++ b/dist/XCode/7.0/JsonServiceClient.swift
@@ -2442,7 +2442,7 @@ public extension NSDate {
     }
     
     public var jsonDate:String {
-        let unixEpoch = Int(self.timeIntervalSince1970 * 1000)
+        let unixEpoch = UInt64(self.timeIntervalSince1970 * 1000)
         return "/Date(\(unixEpoch)-0000)/"
     }
     

--- a/dist/XCode/7.1.1/JsonServiceClient.swift
+++ b/dist/XCode/7.1.1/JsonServiceClient.swift
@@ -2447,7 +2447,7 @@ public extension NSDate {
     }
     
     public var jsonDate:String {
-        let unixEpoch = Int(self.timeIntervalSince1970 * 1000)
+        let unixEpoch = UInt64(self.timeIntervalSince1970 * 1000)
         return "/Date(\(unixEpoch)-0000)/"
     }
     

--- a/dist/XCode/7.1/JsonServiceClient.swift
+++ b/dist/XCode/7.1/JsonServiceClient.swift
@@ -2442,7 +2442,7 @@ public extension NSDate {
     }
     
     public var jsonDate:String {
-        let unixEpoch = Int(self.timeIntervalSince1970 * 1000)
+        let unixEpoch = UInt64(self.timeIntervalSince1970 * 1000)
         return "/Date(\(unixEpoch)-0000)/"
     }
     

--- a/dist/XCode/7.2/JsonServiceClient.swift
+++ b/dist/XCode/7.2/JsonServiceClient.swift
@@ -2447,7 +2447,7 @@ public extension NSDate {
     }
     
     public var jsonDate:String {
-        let unixEpoch = Int(self.timeIntervalSince1970 * 1000)
+        let unixEpoch = UInt64(self.timeIntervalSince1970 * 1000)
         return "/Date(\(unixEpoch)-0000)/"
     }
     

--- a/src/ServiceStackClient/ServiceStackClient/DateExtensions.swift
+++ b/src/ServiceStackClient/ServiceStackClient/DateExtensions.swift
@@ -64,7 +64,7 @@ public extension NSDate {
     }
     
     public var jsonDate:String {
-        let unixEpoch = Int(self.timeIntervalSince1970 * 1000)
+        let unixEpoch = UInt64(self.timeIntervalSince1970 * 1000)
         return "/Date(\(unixEpoch)-0000)/"
     }
     


### PR DESCRIPTION
fixes "fatal error: floating point value cannot be converted to Int32 because it is greater than Int32.max" on 32-bit devices (iPhone 4, 4s, 5), when parsing request property (NSDate)
